### PR TITLE
Taint analysis

### DIFF
--- a/KRFAnalysisPass/KRF.cpp
+++ b/KRFAnalysisPass/KRF.cpp
@@ -319,10 +319,11 @@ struct KRF : public ModulePass {
             const Function *callee = call_inst->getCalledFunction();
             if (lookingForErrno && callee && callee->hasName() &&
                 callee->getName().equals("__errno_location")) { // If call to errno
-              for (const auto U : call_inst->users()) { // For every instruction that uses that result
+              for (const auto U :
+                   call_inst->users()) { // For every instruction that uses that result
                 if (const LoadInst *load_inst = dyn_cast<LoadInst>(U)) { // Check if its a load
-                  for (const auto V : // TODO: add weak taint analysis to get through `trunc` and similar
-                                // instructions
+                  for (const auto V : // TODO: add weak taint analysis to get through `trunc` and
+                                      // similar instructions
                        load_inst->users()) {     // Then for every inst that uses *that* result
                     if (dyn_cast<ICmpInst>(V)) { // Check if its a comparison
                       if (Json) {

--- a/triage/triage.py
+++ b/triage/triage.py
@@ -154,7 +154,7 @@ def main():
         with open(fname) as f:
             json_data = f.read()
         data = json.loads(json_data)
-        analyze(data)
+        analyze(data["syscalls"])
     if not JSON:
         if low_arr:
             # print("[ ] Low severity:")


### PR DESCRIPTION
Adds taint analysis to the pass, outputting what syscalls and external calls are called with unchecked errors as parameters.

The triage script has been updated to use the new json structure, but has not been changed to display the new output from the taint analysis functionality.